### PR TITLE
Logik fix dps comp tool tip

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -270,9 +270,6 @@ function GemSelectClass:UpdateSortCache()
 	if self.skillsTab.displayGroup.displaySkillList and self.skillsTab.displayGroup.displaySkillList[1] then
 		for gemId, gemData in pairs(self.gems) do
 			if gemData.grantedEffect.support then
-				if gemData.name == "Decay" then
-					ConPrintf("hello")
-				end
 				for _, activeSkill in ipairs(self.skillsTab.displayGroup.displaySkillList) do
 					if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
 						sortCache.canSupport[gemId] = true
@@ -285,8 +282,7 @@ function GemSelectClass:UpdateSortCache()
 	elseif self.skillsTab.displayGroup.slot then
 		for _, group in ipairs(self.skillsTab.socketGroupList) do
 			local matchingItemSkillSlot = group.source and group.slot and self.skillsTab.displayGroup.slot == group.slot and group.displaySkillList and group.displaySkillList[1]
-			local crossLinkedSlot = group.slot and group.slot == self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot] and group.displaySkillList and group.displaySkillList[1]
-			if matchingItemSkillSlot or crossLinkedSlot then
+			if matchingItemSkillSlot then
 				for gemId, gemData in pairs(self.gems) do
 					if gemData.grantedEffect.support then
 						for _, activeSkill in ipairs(group.displaySkillList) do
@@ -298,32 +294,22 @@ function GemSelectClass:UpdateSortCache()
 					end
 				end
 			end
+			for _, crossLinkedSlot in ipairs(group.slot and group.displaySkillList and group.displaySkillList[1] and self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap", "")] or {}) do
+				if crossLinkedSlot == group.slot:gsub(" Swap", "") then
+					for gemId, gemData in pairs(self.gems) do
+						if gemData.grantedEffect.support then
+							for _, activeSkill in ipairs(group.displaySkillList) do
+								if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+									sortCache.canSupport[gemId] = true
+									break
+								end
+							end
+						end
+					end
+				end
+			end
 		end
 	end
-	-- new
---		for _, group in ipairs(self.skillsTab.socketGroupList) do
---		local slotMatch = self.skillsTab.displayGroup.slot and self.skillsTab.displayGroup.slot == group.slot
---		if not slotMatch and self.skillsTab.displayGroup.slot and not self.skillsTab.displayGroup.displaySkillList[1] then
---			for _, slot in ipairs(self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap","")] or {}) do
---				if group.slot and group.slot:gsub(" Swap","") == slot and self.skillsTab.displayGroup.slot:match(" Swap") == group.slot:match(" Swap") then
---					slotMatch = true
---					break
---				end
---			end
---		end
---		if (slotMatch or self.skillsTab.displayGroup == group) and group.displaySkillList and group.displaySkillList[1] then
---			for gemId, gemData in pairs(self.gems) do
---				if gemData.grantedEffect.support then
---					for _, activeSkill in ipairs(group.displaySkillList) do
---						if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
---							sortCache.canSupport[gemId] = true
---							break
---						end
---					end
---				end
---			end
---		end
---	end
 
 	local dpsField = self.skillsTab.sortGemsByDPSField
 	GlobalCache.useFullDPS = dpsField == "FullDPS"

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -265,29 +265,65 @@ function GemSelectClass:UpdateSortCache()
 	self.sortCache = sortCache
 
 	-- Determine supports that affect the active skill
-	for _, group in ipairs(self.skillsTab.socketGroupList) do
-		local slotMatch = self.skillsTab.displayGroup.slot and self.skillsTab.displayGroup.slot == group.slot
-		if not slotMatch and self.skillsTab.displayGroup.slot and not self.skillsTab.displayGroup.displaySkillList[1] then
-			for _, slot in ipairs(self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap","")] or {}) do
-				if group.slot and group.slot:gsub(" Swap","") == slot and self.skillsTab.displayGroup.slot:match(" Swap") == group.slot:match(" Swap") then
-					slotMatch = true
-					break
+	-- old
+	-- if active gem exists in socketgroup
+	if self.skillsTab.displayGroup.displaySkillList and self.skillsTab.displayGroup.displaySkillList[1] then
+		for gemId, gemData in pairs(self.gems) do
+			if gemData.grantedEffect.support then
+				if gemData.name == "Decay" then
+					ConPrintf("hello")
+				end
+				for _, activeSkill in ipairs(self.skillsTab.displayGroup.displaySkillList) do
+					if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+						sortCache.canSupport[gemId] = true
+						break
+					end
 				end
 			end
 		end
-		if (slotMatch or self.skillsTab.displayGroup == group) and group.displaySkillList and group.displaySkillList[1] then
-			for gemId, gemData in pairs(self.gems) do
-				if gemData.grantedEffect.support then
-					for _, activeSkill in ipairs(group.displaySkillList) do
-						if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
-							sortCache.canSupport[gemId] = true
-							break
+	-- no active gem exists in socketgroup so check for item provided skills in matching slots
+	elseif self.skillsTab.displayGroup.slot then
+		for _, group in ipairs(self.skillsTab.socketGroupList) do
+			local matchingItemSkillSlot = group.source and group.slot and self.skillsTab.displayGroup.slot == group.slot and group.displaySkillList and group.displaySkillList[1]
+			local crossLinkedSlot = group.slot and group.slot == self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot] and group.displaySkillList and group.displaySkillList[1]
+			if matchingItemSkillSlot or crossLinkedSlot then
+				for gemId, gemData in pairs(self.gems) do
+					if gemData.grantedEffect.support then
+						for _, activeSkill in ipairs(group.displaySkillList) do
+							if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+								sortCache.canSupport[gemId] = true
+								break
+							end
 						end
 					end
 				end
 			end
 		end
 	end
+	-- new
+--		for _, group in ipairs(self.skillsTab.socketGroupList) do
+--		local slotMatch = self.skillsTab.displayGroup.slot and self.skillsTab.displayGroup.slot == group.slot
+--		if not slotMatch and self.skillsTab.displayGroup.slot and not self.skillsTab.displayGroup.displaySkillList[1] then
+--			for _, slot in ipairs(self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap","")] or {}) do
+--				if group.slot and group.slot:gsub(" Swap","") == slot and self.skillsTab.displayGroup.slot:match(" Swap") == group.slot:match(" Swap") then
+--					slotMatch = true
+--					break
+--				end
+--			end
+--		end
+--		if (slotMatch or self.skillsTab.displayGroup == group) and group.displaySkillList and group.displaySkillList[1] then
+--			for gemId, gemData in pairs(self.gems) do
+--				if gemData.grantedEffect.support then
+--					for _, activeSkill in ipairs(group.displaySkillList) do
+--						if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+--							sortCache.canSupport[gemId] = true
+--							break
+--						end
+--					end
+--				end
+--			end
+--		end
+--	end
 
 	local dpsField = self.skillsTab.sortGemsByDPSField
 	GlobalCache.useFullDPS = dpsField == "FullDPS"


### PR DESCRIPTION
### Description of the problem being solved:
Updating the logic for each socket group to be a link group.
This means that supports gems will only affect:
- The socket group that it is placed in
- Any skills provided by items (this checks the `socketGroup.source` property)
- Any active skills in cross linked socket groups. i.e. supports in squire would apply to all socket groups in the weapon

Furthermore this updates the logic for displayed gems:
- If a socket group has skill gem/s - it will only display valid supports for those skill/s
- Else if the socket group has a slot selected which has a corresponding active skill provided by either a unique item or cross-linked socket-group. It will display valid support gems for those skill/s
- Otherwise it will display all gems

### Steps taken to verify a working solution:
- Tested with Squire and Uul Netol's vow for crosslinked slots
- Tested with Arakaalis, Abberath's Hooves, Allelopathy to confirm item skill functionality
- Tested with weapon slots
- Dialla's Malefaction socket functionality unaffected