### PR TITLE
Fix duplicate gems and skill tab tooltips 

### DIFF
--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -270,9 +270,6 @@ function GemSelectClass:UpdateSortCache()
 	if self.skillsTab.displayGroup.displaySkillList and self.skillsTab.displayGroup.displaySkillList[1] then
 		for gemId, gemData in pairs(self.gems) do
 			if gemData.grantedEffect.support then
-				if gemData.name == "Decay" then
-					ConPrintf("hello")
-				end
 				for _, activeSkill in ipairs(self.skillsTab.displayGroup.displaySkillList) do
 					if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
 						sortCache.canSupport[gemId] = true
@@ -285,8 +282,7 @@ function GemSelectClass:UpdateSortCache()
 	elseif self.skillsTab.displayGroup.slot then
 		for _, group in ipairs(self.skillsTab.socketGroupList) do
 			local matchingItemSkillSlot = group.source and group.slot and self.skillsTab.displayGroup.slot == group.slot and group.displaySkillList and group.displaySkillList[1]
-			local crossLinkedSlot = group.slot and group.slot == self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot] and group.displaySkillList and group.displaySkillList[1]
-			if matchingItemSkillSlot or crossLinkedSlot then
+			if matchingItemSkillSlot then
 				for gemId, gemData in pairs(self.gems) do
 					if gemData.grantedEffect.support then
 						for _, activeSkill in ipairs(group.displaySkillList) do
@@ -298,32 +294,22 @@ function GemSelectClass:UpdateSortCache()
 					end
 				end
 			end
+			for _, crossLinkedSlot in ipairs(group.slot and group.displaySkillList and group.displaySkillList[1] and self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap", "")] or {}) do
+				if crossLinkedSlot == group.slot:gsub(" Swap", "") then
+					for gemId, gemData in pairs(self.gems) do
+						if gemData.grantedEffect.support then
+							for _, activeSkill in ipairs(group.displaySkillList) do
+								if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+									sortCache.canSupport[gemId] = true
+									break
+								end
+							end
+						end
+					end
+				end
+			end
 		end
 	end
-	-- new
---		for _, group in ipairs(self.skillsTab.socketGroupList) do
---		local slotMatch = self.skillsTab.displayGroup.slot and self.skillsTab.displayGroup.slot == group.slot
---		if not slotMatch and self.skillsTab.displayGroup.slot and not self.skillsTab.displayGroup.displaySkillList[1] then
---			for _, slot in ipairs(self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap","")] or {}) do
---				if group.slot and group.slot:gsub(" Swap","") == slot and self.skillsTab.displayGroup.slot:match(" Swap") == group.slot:match(" Swap") then
---					slotMatch = true
---					break
---				end
---			end
---		end
---		if (slotMatch or self.skillsTab.displayGroup == group) and group.displaySkillList and group.displaySkillList[1] then
---			for gemId, gemData in pairs(self.gems) do
---				if gemData.grantedEffect.support then
---					for _, activeSkill in ipairs(group.displaySkillList) do
---						if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
---							sortCache.canSupport[gemId] = true
---							break
---						end
---					end
---				end
---			end
---		end
---	end
 
 	local dpsField = self.skillsTab.sortGemsByDPSField
 	GlobalCache.useFullDPS = dpsField == "FullDPS"

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -265,29 +265,65 @@ function GemSelectClass:UpdateSortCache()
 	self.sortCache = sortCache
 
 	-- Determine supports that affect the active skill
-	for _, group in ipairs(self.skillsTab.socketGroupList) do
-		local slotMatch = self.skillsTab.displayGroup.slot and self.skillsTab.displayGroup.slot == group.slot
-		if not slotMatch and self.skillsTab.displayGroup.slot and not self.skillsTab.displayGroup.displaySkillList[1] then
-			for _, slot in ipairs(self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap","")] or {}) do
-				if group.slot and group.slot:gsub(" Swap","") == slot and self.skillsTab.displayGroup.slot:match(" Swap") == group.slot:match(" Swap") then
-					slotMatch = true
-					break
+	-- old
+	-- if active gem exists in socketgroup
+	if self.skillsTab.displayGroup.displaySkillList and self.skillsTab.displayGroup.displaySkillList[1] then
+		for gemId, gemData in pairs(self.gems) do
+			if gemData.grantedEffect.support then
+				if gemData.name == "Decay" then
+					ConPrintf("hello")
+				end
+				for _, activeSkill in ipairs(self.skillsTab.displayGroup.displaySkillList) do
+					if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+						sortCache.canSupport[gemId] = true
+						break
+					end
 				end
 			end
 		end
-		if (slotMatch or self.skillsTab.displayGroup == group) and group.displaySkillList and group.displaySkillList[1] then
-			for gemId, gemData in pairs(self.gems) do
-				if gemData.grantedEffect.support then
-					for _, activeSkill in ipairs(group.displaySkillList) do
-						if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
-							sortCache.canSupport[gemId] = true
-							break
+	-- no active gem exists in socketgroup so check for item provided skills in matching slots
+	elseif self.skillsTab.displayGroup.slot then
+		for _, group in ipairs(self.skillsTab.socketGroupList) do
+			local matchingItemSkillSlot = group.source and group.slot and self.skillsTab.displayGroup.slot == group.slot and group.displaySkillList and group.displaySkillList[1]
+			local crossLinkedSlot = group.slot and group.slot == self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot] and group.displaySkillList and group.displaySkillList[1]
+			if matchingItemSkillSlot or crossLinkedSlot then
+				for gemId, gemData in pairs(self.gems) do
+					if gemData.grantedEffect.support then
+						for _, activeSkill in ipairs(group.displaySkillList) do
+							if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+								sortCache.canSupport[gemId] = true
+								break
+							end
 						end
 					end
 				end
 			end
 		end
 	end
+	-- new
+--		for _, group in ipairs(self.skillsTab.socketGroupList) do
+--		local slotMatch = self.skillsTab.displayGroup.slot and self.skillsTab.displayGroup.slot == group.slot
+--		if not slotMatch and self.skillsTab.displayGroup.slot and not self.skillsTab.displayGroup.displaySkillList[1] then
+--			for _, slot in ipairs(self.skillsTab.build.calcsTab.mainEnv.crossLinkedSupportGroups[self.skillsTab.displayGroup.slot:gsub(" Swap","")] or {}) do
+--				if group.slot and group.slot:gsub(" Swap","") == slot and self.skillsTab.displayGroup.slot:match(" Swap") == group.slot:match(" Swap") then
+--					slotMatch = true
+--					break
+--				end
+--			end
+--		end
+--		if (slotMatch or self.skillsTab.displayGroup == group) and group.displaySkillList and group.displaySkillList[1] then
+--			for gemId, gemData in pairs(self.gems) do
+--				if gemData.grantedEffect.support then
+--					for _, activeSkill in ipairs(group.displaySkillList) do
+--						if calcLib.canGrantedEffectSupportActiveSkill(gemData.grantedEffect, activeSkill) then
+--							sortCache.canSupport[gemId] = true
+--							break
+--						end
+--					end
+--				end
+--			end
+--		end
+--	end
 
 	local dpsField = self.skillsTab.sortGemsByDPSField
 	GlobalCache.useFullDPS = dpsField == "FullDPS"

--- a/src/Classes/GemSelectControl.lua
+++ b/src/Classes/GemSelectControl.lua
@@ -81,13 +81,22 @@ function GemSelectClass:CalcOutputWithThisGem(calcFunc, gemData, qualityId)
 	local gemInstance = gemList[self.index]
 	gemInstance.level = self.skillsTab:ProcessGemLevel(gemData)
 	gemInstance.gemData = gemData
+	gemInstance.displayEffect = nil
+	if gemInstance.qualityId == nil or gemInstance.qualityId == "" then
+		gemInstance.qualityId = "Default"
+	end
+	-- Add hovered gem to tooltip
+	self:AddGemTooltip(gemInstance)
 	-- Calculate the impact of using this gem
 	local output = calcFunc({ }, { allocNodes = true, requirementsItems = true })
+	-- Put the original gem back into the list
 	if oldGem then
 		gemInstance.gemData = oldGem.gemData
 		gemInstance.level = oldGem.level
+		gemInstance.displayEffect = oldGem.displayEffect
 	else
 		gemList[self.index] = nil
+		calcFunc({ }, { allocNodes = true, requirementsItems = true })
 	end
 
 	return output, gemInstance
@@ -465,7 +474,6 @@ function GemSelectClass:Draw(viewPort, noTooltip)
 				self.tooltip:Clear()
 				local output, gemInstance = self:CalcOutputWithThisGem(calcFunc, self.gems[self.list[self.hoverSel]], self:GetQualityType(self.list[self.hoverSel]))
 				self.tooltip:AddSeparator(10)
-				self:AddGemTooltip(gemInstance)
 				self.skillsTab.build:AddStatComparesToTooltip(self.tooltip, calcBase, output, "^7Selecting this gem will give you:")
 				self.tooltip:Draw(x, y + height + 2 + (self.hoverSel - 1) * (height - 4) - scrollBar.offset, width, height - 4, viewPort)
 			end

--- a/src/Classes/SkillsTab.lua
+++ b/src/Classes/SkillsTab.lua
@@ -1203,7 +1203,7 @@ function SkillsTabClass:AddSocketGroupTooltip(tooltip, socketGroup)
 		end
 	end
 	local showOtherHeader = true
-	for _, gemInstance in ipairs(socketGroup.gemList) do
+	for _, gemInstance in ipairs(socketGroup.displayGemList or socketGroup.gemList) do
 		if not gemShown[gemInstance] then
 			if showOtherHeader then
 				showOtherHeader = false


### PR DESCRIPTION
### Description of the problem being solved:
Previous changes allowed two socket groups with the same gem to apply to item provided skills.
This PR implements a fix by adding an `appliedSupportGroup` section which calculates which supports are superseded before creating the active skill. 

Another issue was the skill tab tooltips only displayed the applied gems for item provided skills/crosslinked sockets rather than all linked gems with the corresponding superseded/disabled tags. 
This PR implements a fix by adding a `displayGemList` property that is created on the socketGroup and sets the tooltip to prioritise the `displayGemList` over `gemList` if it exists. 

### Steps taken to verify a working solution:
- Tested with Arakaali + Squire with duplicated socket groups and duplicated gems
- Tested with Abberaths hooves with multiple socket groups
