### PR TITLE
Log busted-diff output to file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ luajit/
 spec/test_results.log
 spec/test_generation.log
 src/luacov.stats.out
+spec/logs/
 
 # Release
 manifest-updated.xml

--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@ luajit/
 spec/test_results.log
 spec/test_generation.log
 src/luacov.stats.out
-spec/logs/
+spec/test_diffoutput.log
 
 # Release
 manifest-updated.xml

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,6 +21,7 @@ services:
       WORKDIR: /workdir
       CACHEDIR: /cache
       HOME: /tmp
+      LOGDIR: /logs
     container_name: busted-diff
     tty: true
     user: nobody:nobody
@@ -31,3 +32,4 @@ services:
     volumes:
       - ./:/workdir:ro
       - "${CACHEDIR:-/tmp}:/cache"
+      - ./spec/logs:/logs

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -32,4 +32,4 @@ services:
     volumes:
       - ./:/workdir:ro
       - "${CACHEDIR:-/tmp}:/cache"
-      - ./spec/logs:/logs
+      - ./spec:/logs

--- a/spec/buildDiff.sh
+++ b/spec/buildDiff.sh
@@ -5,7 +5,7 @@ git config --global --add safe.directory /workdir
 git config --global --add advice.detachedHead false
 headref=$(git rev-parse HEAD)
 devref=$(git rev-parse origin/dev)
-diffoutputlog=$LOGDIR/diffoutput.log
+diffoutputlog=$LOGDIR/test_diffoutput.log
 rm -f $diffoutputlog
 
 if [[ ! -f "$CACHEDIR/$devref" ]] # Output of builds outdated or nonexistent

--- a/spec/buildDiff.sh
+++ b/spec/buildDiff.sh
@@ -5,6 +5,8 @@ git config --global --add safe.directory /workdir
 git config --global --add advice.detachedHead false
 headref=$(git rev-parse HEAD)
 devref=$(git rev-parse origin/dev)
+diffoutputlog=$LOGDIR/diffoutput.log
+rm -f $diffoutputlog
 
 if [[ ! -f "$CACHEDIR/$devref" ]] # Output of builds outdated or nonexistent
 then
@@ -34,8 +36,10 @@ then
     for build in $CACHEDIR/*.build
     do
         BASENAME=$(basename "$build")
-        echo "[-] Savefile Diff for $BASENAME"
-        diff "$build" "/tmp/$BASENAME"
-        echo "[+] Savefile Diff for $BASENAME"
+        if ! cmp -s "$build" "/tmp/$BASENAME"; then
+            echo "[-] Savefile Diff for $BASENAME" | tee -a $diffoutputlog
+            diff "$build" "/tmp/$BASENAME" | tee -a $diffoutputlog
+            echo "[+] Savefile Diff for $BASENAME" | tee -a $diffoutputlog
+        fi
     done
 fi


### PR DESCRIPTION
### Changes
- Add `test_diffoutput.log` to gitignore
- Added a `LOGDIR` environment variable to the `busted_diff` docker service which points to the `spec` folder
- Updated `buildDiff.sh` to output build differences to `test_diffoutput.log` and only when there are differences 

I have very little experience with shell scripting and docker so the way I've done things might be wrong/suboptimal. More than happy to modify based on feedback.
