### PR TITLE
Fix headless callbacks

### DIFF
--- a/src/HeadlessWrapper.lua
+++ b/src/HeadlessWrapper.lua
@@ -7,26 +7,6 @@
 -- bodies intended for headless use.
 dofile("_SimpleGraphic.def.lua")
 
--- Callbacks
-local callbackTable = { }
-local mainObject
-function runCallback(name, ...)
-	if callbackTable[name] then
-		return callbackTable[name](...)
-	elseif mainObject and mainObject[name] then
-		return mainObject[name](mainObject, ...)
-	end
-end
-function SetCallback(name, func)
-	callbackTable[name] = func
-end
-function GetCallback(name)
-	return callbackTable[name]
-end
-function SetMainObject(obj)
-	mainObject = obj
-end
-
 -- https://stackoverflow.com/questions/19326368/iterate-over-lines-including-blank-lines
 function splitLines(s)
 	if s:sub(-1)~="\n" then s=s.."\n" end


### PR DESCRIPTION
### Description of the problem being solved:
This fixes the __mainObject__ nil error during headless startup. HeadlessWrapper.lua still had old callback functions that overrode the ones loaded from _SimpleGraphic.def.lua. Those functions were setting the old local variables, while the newer wrapper was reading __mainObject__ and __callbackTable__.

### Steps taken to verify a working solution:
Tested locally against `tests-branch` at `59c25d23` using the official PoB test container.
- Confirmed the startup error before the fix and successful startup afterward.
- Loaded and calculated all 500 builds from the live pob.codes API in batches of 50. Also checked callback registration and dispatch.
- Ran the existing unit tests: 583 passed, with one failure in the trade-query 401 response test.

### Link to a build that showcases this PR:

### Before screenshot:

### After screenshot:
